### PR TITLE
「所属大学」→「大学切替」に変更

### DIFF
--- a/app/views/activity_watcher/courses/_form.html.erb
+++ b/app/views/activity_watcher/courses/_form.html.erb
@@ -44,7 +44,7 @@
           </div>
 
           <div class="form-group">
-            <div>所属大学</div>
+            <div>大学切替</div>
             <%= f.input :university_id, label: false do %>
               <%= f.select :university_id, @universities.map { |u| [u.name, u.id] }, {}, class: "form-control edit-right-area__university" %>
             <% end %>


### PR DESCRIPTION
./app/views/activity_watcher/courses/_form.html.erb:            <div>所属大学</div>
を変えました。
./app/models/user.rb:    "の所属大学が重複しています") 
./app/assets/javascripts/sessions.js:  // 所属大学の子要素があるページだったら
./config/locales/ja.yml:        university_id: 所属大学
./config/locales/ja.yml:        university_id: 所属大学
は変えると変だと思い変更していません。
![2017-12-12 19 17 21](https://user-images.githubusercontent.com/12641352/33890108-9b085f30-df95-11e7-80d0-dccf5874e36e.png)

