### PR TITLE
コースへの参加取りやめ機能と参加・取りやめ時のアラートを追加

### DIFF
--- a/app/controllers/activity_watcher/courses_controller.rb
+++ b/app/controllers/activity_watcher/courses_controller.rb
@@ -64,7 +64,7 @@ class ActivityWatcher::CoursesController < ActivityWatcher::BaseController
   def entry
     respond_to do |format|
       if Course.create_or_destroy_participant(params[:id], current_user.id, params[:participate])
-        if params[:participate]
+        if params[:participate] == "cancel"
           notice = 'コースへの参加を取り消しました'
         else
           notice = 'コースへの参加登録が完了しました'

--- a/app/controllers/activity_watcher/courses_controller.rb
+++ b/app/controllers/activity_watcher/courses_controller.rb
@@ -63,8 +63,13 @@ class ActivityWatcher::CoursesController < ActivityWatcher::BaseController
   
   def entry
     respond_to do |format|
-      if Course.create_participant(params[:id], current_user.id)
-        format.html { redirect_to list_courses_url, notice: 'コースへの参加登録が完了しました' }
+      if Course.create_or_destroy_participant(params[:id], current_user.id, params[:participate])
+        if params[:participate]
+          notice = 'コースへの参加を取り消しました'
+        else
+          notice = 'コースへの参加登録が完了しました'
+        end
+        format.html { redirect_to list_courses_url, notice: notice }
       else
         format.html { render action: 'list' }
       end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -30,11 +30,13 @@ class Course < ApplicationRecord
         university_id: university_id).order(id: :desc)
     end
   
-    def create_participant(course_id, user_id)
+    def create_or_destroy_participant(course_id, user_id, participate = nil)
       cp = CourseParticipant.find_or_initialize_by(course_id: course_id, user_id: user_id)
       if cp.new_record?
         return false if cp.invalid?
         cp.save
+      elsif participate.present? && participate == "cancel"
+        cp.destroy
       end
       true
     end

--- a/app/views/activity_watcher/courses/detail.html.erb
+++ b/app/views/activity_watcher/courses/detail.html.erb
@@ -26,7 +26,7 @@
           <% if @participant.present? || current_user.Teacher? %>
             <%= link_to '課題一覧を見る', list__course_tasks_url(@course.id), class: "btn btn-success" %>
             <%= link_to '参加を取りやめる', entry_course_url(@course.id, participate: "cancel"), data: {confirm: "参加を取りやめます。よろしいですか？"},
-                  class: "btn btn-danger" if (@time_current >= @course.start_date) && (@time_current <= @course.end_date) %>
+              class: "btn btn-danger" if (@time_current >= @course.start_date) && (@time_current <= @course.end_date) && current_user.Student? %>
           <% elsif (@time_current >= @course.start_date) && (@time_current <= @course.end_date) %>
             <%= link_to 'コースに参加する', entry_course_url(@course.id), data: {confirm: "このコースに参加します。よろしいですか？"}, class: "btn btn-primary" %>
           <% end %>

--- a/app/views/activity_watcher/courses/detail.html.erb
+++ b/app/views/activity_watcher/courses/detail.html.erb
@@ -25,8 +25,10 @@
           <%= link_to '一覧に戻る', list_courses_url ,class: "btn btn-default" %>
           <% if @participant.present? || current_user.Teacher? %>
             <%= link_to '課題一覧を見る', list__course_tasks_url(@course.id), class: "btn btn-success" %>
+            <%= link_to '参加を取りやめる', entry_course_url(@course.id, participate: "cancel"), data: {confirm: "参加を取りやめます。よろしいですか？"},
+                  class: "btn btn-danger" if (@time_current >= @course.start_date) && (@time_current <= @course.end_date) %>
           <% elsif (@time_current >= @course.start_date) && (@time_current <= @course.end_date) %>
-            <%= link_to 'コースに参加する', entry_course_url(@course.id), class: "btn btn-primary" %>
+            <%= link_to 'コースに参加する', entry_course_url(@course.id), data: {confirm: "このコースに参加します。よろしいですか？"}, class: "btn btn-primary" %>
           <% end %>
         </td>
       </tr>

--- a/app/views/activity_watcher/courses/list.html.erb
+++ b/app/views/activity_watcher/courses/list.html.erb
@@ -30,8 +30,10 @@
               <%= link_to list__course_tasks_url(course.id) do %>
                 <button type="button" class="btn btn-success">課題一覧を見る</button>
               <% end %>
+              <%= link_to "参加を取りやめる", entry_course_path(course.id, participate: "cancel"), data: {confirm: "参加を取りやめます。よろしいですか？"},
+                  class: "btn btn-danger" if (course.start_date <= @time_current) && (course.end_date >= @time_current) %>
             <% elsif (course.start_date <= @time_current) && (course.end_date >= @time_current) %>
-              <%= link_to entry_course_path(course.id) do %>
+              <%= link_to entry_course_path(course.id), data: {confirm: "このコースに参加します。よろしいですか？"} do %>
                 <button type="button" class="btn btn-primary">コースに参加する</button>
               <% end %>
             <% end %>

--- a/app/views/activity_watcher/courses/list.html.erb
+++ b/app/views/activity_watcher/courses/list.html.erb
@@ -31,7 +31,7 @@
                 <button type="button" class="btn btn-success">課題一覧を見る</button>
               <% end %>
               <%= link_to "参加を取りやめる", entry_course_path(course.id, participate: "cancel"), data: {confirm: "参加を取りやめます。よろしいですか？"},
-                  class: "btn btn-danger" if (course.start_date <= @time_current) && (course.end_date >= @time_current) %>
+                class: "btn btn-danger" if (course.start_date <= @time_current) && (course.end_date >= @time_current) && current_user.Student? %>
             <% elsif (course.start_date <= @time_current) && (course.end_date >= @time_current) %>
               <%= link_to entry_course_path(course.id), data: {confirm: "このコースに参加します。よろしいですか？"} do %>
                 <button type="button" class="btn btn-primary">コースに参加する</button>


### PR DESCRIPTION
```
courses_controller.rb
・entryアクションで追加・削除両方対応させるため、取りやめ時用のパラメータを受け取れるよう修正
・↑のパラメータの有無でnoticeを出し分け

models/course.rb
・createのみ行っていたメソッドをdestroyにも対応できるよう修正

views/courses/list.html.erb, detail.html.erb
・コース参加・取りやめ押下時のアラートを追加
・参加取りやめのリンク表示制御を追加(コース開講期間中のみ)
```